### PR TITLE
Feat : 게시물 통계 데이터 조회 기능 service 레이어 코드 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
 import { validate } from './common/env.validation';
 import { MongooseModule } from '@nestjs/mongoose';
+import { StatisticsModule } from './statistics/statistics.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { MongooseModule } from '@nestjs/mongoose';
         password: process.env.DATABASE_PASS,
       },
     }),
+    StatisticsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/statistics/schema/statistics.model.ts
+++ b/src/statistics/schema/statistics.model.ts
@@ -1,0 +1,29 @@
+import { InjectModel } from '@nestjs/mongoose';
+import { Statistics, StatisticsDocument } from './statistics.schema';
+import { Model } from 'mongoose';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class StatisticsModel {
+  constructor(
+    @InjectModel(Statistics.name)
+    private statisticsModel: Model<StatisticsDocument>,
+  ) {}
+
+  /**
+   * @author 명석
+   * @desc StatisticsService 테스트 코드 작성을 위해 임의로 작성된 메서드입니다.
+   * @todo model 메서드 작성 후 주석 삭제
+   */
+  async getArticleStatistics(
+    args: unknown,
+  ): Promise<{ createdAt: Date; counts: number }[]> {
+    console.log('args: ', args);
+    return [
+      { createdAt: new Date('2023-10-01'), counts: 1 },
+      { createdAt: new Date('2023-10-02'), counts: 2 },
+      { createdAt: new Date('2023-10-03'), counts: 3 },
+      { createdAt: new Date('2023-10-27'), counts: 4 },
+    ];
+  }
+}

--- a/src/statistics/schema/statistics.schema.ts
+++ b/src/statistics/schema/statistics.schema.ts
@@ -1,0 +1,14 @@
+import { Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type StatisticsDocument = HydratedDocument<Statistics>;
+
+/**
+ * @author 명석
+ * @desc service 테스트 코드 작성을 위해 선언만 해두었습니다. 필드는 model 작업 시, 추가할 예정입니다.
+ * @todo model 코드 작성 후 주석 삭제
+ */
+@Schema({ timestamps: true, collection: 'statistics' })
+export class Statistics {}
+
+export const StatisticsSchema = SchemaFactory.createForClass(Statistics);

--- a/src/statistics/statistics.controller.spec.ts
+++ b/src/statistics/statistics.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatisticsController } from './statistics.controller';
+
+describe('StatisticsController', () => {
+  let controller: StatisticsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StatisticsController],
+    }).compile();
+
+    controller = module.get<StatisticsController>(StatisticsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/statistics/statistics.controller.ts
+++ b/src/statistics/statistics.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('statistics')
+export class StatisticsController {}

--- a/src/statistics/statistics.module.ts
+++ b/src/statistics/statistics.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { StatisticsService } from './statistics.service';
+import { StatisticsController } from './statistics.controller';
+import { Statistics, StatisticsSchema } from './schema/statistics.schema';
+import { MongooseModule } from '@nestjs/mongoose';
+import { StatisticsModel } from './schema/statistics.model';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Statistics.name, schema: StatisticsSchema },
+    ]),
+  ],
+  controllers: [StatisticsController],
+  providers: [StatisticsService, StatisticsModel],
+})
+export class StatisticsModule {}

--- a/src/statistics/statistics.service.spec.ts
+++ b/src/statistics/statistics.service.spec.ts
@@ -1,0 +1,264 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QueryType, StatisticsService } from './statistics.service';
+import { QueryPeriod, QueryValue } from './statistics.type';
+import { StatisticsModel } from './schema/statistics.model';
+
+/**
+ * @author 명석
+ * @desc StatisticsModel 생성 전 임시로 사용하기 위해 임의의 mockModel 함수를 선언하여 사용합니다.
+ */
+describe('StatisticsService', () => {
+  let statisticsService: StatisticsService;
+  let statisticsModel: StatisticsModel;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StatisticsService,
+        {
+          provide: StatisticsModel,
+          useValue: {
+            getArticleStatistics: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    statisticsService = module.get<StatisticsService>(StatisticsService);
+    statisticsModel = module.get(StatisticsModel);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(statisticsService).toBeDefined();
+  });
+
+  describe('getArticleStatistics', () => {
+    it('SUCCESS: "일자별(date)" "게시물 수(count)" 요청 시, 일자별 게시물 수 데이터를 리턴', async () => {
+      const mockDto: QueryType = {
+        hashtag: '이명석',
+        type: QueryPeriod.DATE,
+        start: new Date('2023-10-01T00:00:00Z'),
+        end: new Date('2023-10-27T00:23:59Z'),
+        value: QueryValue.COUNT,
+      };
+
+      const expectedResult = [
+        { createdAt: new Date('2023-10-01'), counts: 1 },
+        { createdAt: new Date('2023-10-02'), counts: 2 },
+        { createdAt: new Date('2023-10-03'), counts: 3 },
+        { createdAt: new Date('2023-10-27'), counts: 4 },
+      ];
+
+      jest
+        .spyOn(statisticsModel, 'getArticleStatistics')
+        .mockResolvedValue(expectedResult);
+
+      const result = await statisticsService.getArticleStatistics(mockDto);
+
+      expect(result).toStrictEqual(expectedResult);
+      expect(statisticsModel.getArticleStatistics).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('SUCCESS: "일자별(date)" "게시물 조회 수(viewCount)" 요청 시, 일자별 게시물 조회 수 데이터를 리턴 ', async () => {
+      const mockDto: QueryType = {
+        hashtag: '이명석',
+        type: QueryPeriod.DATE,
+        start: new Date('2023-10-01T00:00:00Z'),
+        end: new Date('2023-10-27T00:23:59Z'),
+        value: QueryValue.VIEW_COUNT,
+      };
+
+      const expectedResult = [
+        { createdAt: new Date('2023-10-01'), counts: 1 },
+        { createdAt: new Date('2023-10-02'), counts: 2 },
+        { createdAt: new Date('2023-10-03'), counts: 3 },
+        { createdAt: new Date('2023-10-27'), counts: 4 },
+      ];
+
+      jest
+        .spyOn(statisticsModel, 'getArticleStatistics')
+        .mockResolvedValue(expectedResult);
+
+      const result = await statisticsService.getArticleStatistics(mockDto);
+
+      expect(result).toStrictEqual(expectedResult);
+      expect(statisticsModel.getArticleStatistics).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('SUCCESS: "일자별(date)" "게시물 좋아요 수(likeCount)" 요청 시, 일자별 게시물 좋아요 수 데이터를 리턴', async () => {
+      const mockDto: QueryType = {
+        hashtag: '이명석',
+        type: QueryPeriod.DATE,
+        start: new Date('2023-10-01T00:00:00Z'),
+        end: new Date('2023-10-27T00:23:59Z'),
+        value: QueryValue.LIKE_COUNT,
+      };
+
+      const expectedResult = [
+        { createdAt: new Date('2023-10-01'), counts: 1 },
+        { createdAt: new Date('2023-10-02'), counts: 2 },
+        { createdAt: new Date('2023-10-03'), counts: 3 },
+        { createdAt: new Date('2023-10-27'), counts: 4 },
+      ];
+
+      jest
+        .spyOn(statisticsModel, 'getArticleStatistics')
+        .mockResolvedValue(expectedResult);
+
+      const result = await statisticsService.getArticleStatistics(mockDto);
+
+      expect(result).toStrictEqual(expectedResult);
+      expect(statisticsModel.getArticleStatistics).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('SUCCESS: "일자별" "게시물 공유 수(shareCount)" 요청 시, 일자별 게시물 공유 수 데이터를 리턴', async () => {
+      const mockDto: QueryType = {
+        hashtag: '이명석',
+        type: QueryPeriod.DATE,
+        start: new Date('2023-10-01T00:00:00Z'),
+        end: new Date('2023-10-27T00:23:59Z'),
+        value: QueryValue.SHARE_COUNT,
+      };
+
+      const expectedResult = [
+        { createdAt: new Date('2023-10-01'), counts: 1 },
+        { createdAt: new Date('2023-10-02'), counts: 2 },
+        { createdAt: new Date('2023-10-03'), counts: 3 },
+        { createdAt: new Date('2023-10-27'), counts: 4 },
+      ];
+
+      jest
+        .spyOn(statisticsModel, 'getArticleStatistics')
+        .mockResolvedValue(expectedResult);
+
+      const result = await statisticsService.getArticleStatistics(mockDto);
+
+      expect(result).toStrictEqual(expectedResult);
+      expect(statisticsModel.getArticleStatistics).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('SUCCESS: "시간별(hour)" "게시물 수(count)" 요청 시, 시간별 게시물 수 데이터를 리턴', async () => {
+      const mockDto: QueryType = {
+        hashtag: '이명석',
+        type: QueryPeriod.HOUR,
+        start: new Date('2023-10-01T00:00:00Z'),
+        end: new Date('2023-10-27T00:00:00Z'),
+        value: QueryValue.COUNT,
+      };
+
+      const expectedResult = [
+        { createdAt: new Date('2023-10-01T00:00:00Z'), counts: 1 },
+        { createdAt: new Date('2023-10-02T00:00:00Z'), counts: 2 },
+        { createdAt: new Date('2023-10-03T00:00:00Z'), counts: 3 },
+        { createdAt: new Date('2023-10-27T00:00:00Z'), counts: 4 },
+      ];
+
+      jest
+        .spyOn(statisticsModel, 'getArticleStatistics')
+        .mockResolvedValue(expectedResult);
+
+      const result = await statisticsService.getArticleStatistics(mockDto);
+
+      expect(result).toStrictEqual(expectedResult);
+      expect(statisticsModel.getArticleStatistics).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('SUCCESS: "시간별(hour)" "게시물 조회 수(viewCount)" 요청 시, 시간별 게시물 조회 수 데이터를 리턴 ', async () => {
+      const mockDto: QueryType = {
+        hashtag: '이명석',
+        type: QueryPeriod.HOUR,
+        start: new Date('2023-10-01T00:00:00Z'),
+        end: new Date('2023-10-27T00:00:00Z'),
+        value: QueryValue.VIEW_COUNT,
+      };
+
+      const expectedResult = [
+        { createdAt: new Date('2023-10-01T00:00:00Z'), counts: 1 },
+        { createdAt: new Date('2023-10-02T00:00:00Z'), counts: 2 },
+        { createdAt: new Date('2023-10-03T00:00:00Z'), counts: 3 },
+        { createdAt: new Date('2023-10-27T00:00:00Z'), counts: 4 },
+      ];
+
+      jest
+        .spyOn(statisticsModel, 'getArticleStatistics')
+        .mockResolvedValue(expectedResult);
+
+      const result = await statisticsService.getArticleStatistics(mockDto);
+
+      expect(result).toStrictEqual(expectedResult);
+      expect(statisticsModel.getArticleStatistics).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('SUCCESS: "시간별(hour)" "게시물 좋아요 수(likeCount)" 요청 시, 시간별 게시물 좋아요 수 데이터를 리턴', async () => {
+      const mockDto: QueryType = {
+        hashtag: '이명석',
+        type: QueryPeriod.HOUR,
+        start: new Date('2023-10-01T00:00:00Z'),
+        end: new Date('2023-10-27T00:00:00Z'),
+        value: QueryValue.LIKE_COUNT,
+      };
+
+      const expectedResult = [
+        { createdAt: new Date('2023-10-01T00:00:00Z'), counts: 1 },
+        { createdAt: new Date('2023-10-02T00:00:00Z'), counts: 2 },
+        { createdAt: new Date('2023-10-03T00:00:00Z'), counts: 3 },
+        { createdAt: new Date('2023-10-27T00:00:00Z'), counts: 4 },
+      ];
+
+      jest
+        .spyOn(statisticsModel, 'getArticleStatistics')
+        .mockResolvedValue(expectedResult);
+
+      const result = await statisticsService.getArticleStatistics(mockDto);
+
+      expect(result).toStrictEqual(expectedResult);
+      expect(statisticsModel.getArticleStatistics).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('SUCCESS: "시간별(hour)" "게시물 공유 수(shareCount)" 요청 시, 시간별 게시물 공유 수 데이터를 리턴', async () => {
+      const mockDto: QueryType = {
+        hashtag: '이명석',
+        type: QueryPeriod.HOUR,
+        start: new Date('2023-10-01T00:00:00Z'),
+        end: new Date('2023-10-27T00:00:00Z'),
+        value: QueryValue.SHARE_COUNT,
+      };
+
+      const expectedResult = [
+        { createdAt: new Date('2023-10-01T00:00:00Z'), counts: 1 },
+        { createdAt: new Date('2023-10-02T00:00:00Z'), counts: 2 },
+        { createdAt: new Date('2023-10-03T00:00:00Z'), counts: 3 },
+        { createdAt: new Date('2023-10-27T00:00:00Z'), counts: 4 },
+      ];
+
+      jest
+        .spyOn(statisticsModel, 'getArticleStatistics')
+        .mockResolvedValue(expectedResult);
+
+      const result = await statisticsService.getArticleStatistics(mockDto);
+
+      expect(result).toStrictEqual(expectedResult);
+      expect(statisticsModel.getArticleStatistics).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+  });
+});

--- a/src/statistics/statistics.service.ts
+++ b/src/statistics/statistics.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { QueryPeriodType, QueryValueType } from './statistics.type';
+import { StatisticsModel } from './schema/statistics.model';
+
+/**
+ * @author 명석
+ * @desc dto 작성 전, dto 대신 활용하기 위한 타입입니다.
+ * @todo dto 작성 이후 삭제
+ */
+export type QueryType = {
+  hashtag: string | string[];
+  type: QueryPeriodType;
+  start: Date;
+  end: Date;
+  value: QueryValueType;
+};
+
+@Injectable()
+export class StatisticsService {
+  constructor(private readonly statisticsModel: StatisticsModel) {}
+
+  async getArticleStatistics(dto: QueryType) {
+    //todo dto의 hashtag 값이 있는지 검증하는 dto 메서드 추가
+    //todo dto에 hashtag가 없을 경우 accountTag를 hashtag의 값으로 추가하는 메서드 추가
+    const data = await this.statisticsModel.getArticleStatistics(dto as any);
+
+    return data;
+  }
+}

--- a/src/statistics/statistics.type.ts
+++ b/src/statistics/statistics.type.ts
@@ -1,0 +1,15 @@
+export const QueryPeriod = {
+  DATE: 'date',
+  HOUR: 'hour',
+} as const;
+
+export type QueryPeriodType = (typeof QueryPeriod)[keyof typeof QueryPeriod];
+
+export const QueryValue = {
+  COUNT: 'count',
+  VIEW_COUNT: 'viewCount',
+  LIKE_COUNT: 'likeCount',
+  SHARE_COUNT: 'shareCount',
+};
+
+export type QueryValueType = (typeof QueryValue)[keyof typeof QueryValue];


### PR DESCRIPTION
## PR 체크리스트
아래 항목을 확인해 주세요:

- [ ] 커밋 메시지가 우리의 가이드라인을 따르고 있는지 확인하세요
- [ ] 변경 사항에 대한 테스트가 추가되었는지 확인하세요 (버그 수정 / 기능 추가)
- [ ] 문서가 추가되거나 업데이트되었는지 확인하세요 (버그 수정 / 기능 추가)

## PR 유형
이 PR은 어떤 종류의 변경을 가져오나요?

- [ ] 버그 수정
- [x] 새로운 기능 추가
- [ ] 코드 스타일 업데이트 (서식, 로컬 변수)
- [ ] 리팩터링 (기능 변경 없음, API 변경 없음)
- [ ] 빌드 관련 변경
- [ ] CI 관련 변경
- [ ] 문서 내용 변경
- [ ] 애플리케이션 / 인프라 변경
- [ ] 기타... 설명:

## 현재 동작은 무엇인가요?

이슈 번호: #9 

## 새로운 동작은 무엇인가요?
**게시물 통계 데이터를 조회하는 메인 서비스 메서드(getArticleStatistics)를 작성하였습니다.**
- 통계 모듈 작성 시작을 위해 필요한 레이어는 미리 선언만 해두었습니다.

- Layered Architecture(controller, service, schema)이며, 서비스 레이어와 영속성(infra) 레이어의 강결합을 분리하기 위해 repsitory 패턴을 적용하였습니다.

- 함수명은 getArticleStatistics로 네이밍 했으며, 추후 article 외에도 통계 데이터를 다룰 수도 있기에, 함수 이름을 보다 명확히 작성하고자 했습니다.

- unit test coverage는 100%입니다. 아직 메인 서비스 메서드 하나만 구현된 상태이고 SUCCESS인 케이스만 있기 때문에 그렇습니다.
<img width="828" alt="스크린샷 2023-10-27 오후 10 05 26" src="https://github.com/pre-onboarding-backend-G/get-your-feeds/assets/109528794/b1f7accb-09e9-4693-bf63-0ca653717dd9">

- model에서 데이터를 어떻게 가져오느냐에 따라 서비스 함수가 추가될 것으로 예상되며 그 때 TDD를 적용하기 위해 미리 많은 SUCCESS 케이스의 테스트 코드를 추가해 두었습니다.

- 코드 구현 시 필요한 type은 별도로 statistics.type.ts에 추가해두었습니다. 어디서든 재사용 가능한 타입 또는 인터페이스, enum이 여러파일에 타입들이 분산되면 유지보수에 불리한 것 같습니다.

## 이 PR은 호환성 변경을 도입하나요?

- [ ] 예
- [x] 아니요

## 기타 정보
